### PR TITLE
refactor(NewCompletion): changes to NewCompletion func and comments

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -284,21 +284,21 @@ func (i *Info) RootCID() cid.Cid {
 //
 type Completion []uint16
 
-// NewCompletion constructs a progress from
+// NewCompletion constructs a progress from a diff Manifest
 func NewCompletion(mfst, missing *Manifest) Completion {
-	// fill in progress
 	prog := make(Completion, len(mfst.Nodes))
-	for i := range prog {
-		prog[i] = 100
-	}
 
-	// then set missing blocks to 0
-	for _, miss := range missing.Nodes {
-		for i, hash := range mfst.Nodes {
-			if hash == miss {
-				prog[i] = 0
-			}
+	// Since a manifest its diff have their nodes in the same order
+	// we can leverage that info to only have to iterate through the list of
+	// nodes once:
+	m := 0
+	for i, hash := range mfst.Nodes {
+		if m < len(missing.Nodes) && hash == missing.Nodes[m] {
+			prog[i] = 0
+			m++
+			continue
 		}
+		prog[i] = 100
 	}
 
 	return prog

--- a/dsync/fetch.go
+++ b/dsync/fetch.go
@@ -127,6 +127,10 @@ func (f *Fetch) Do() (err error) {
 					}
 
 					if bs.Path().Cid().String() != res.Hash {
+						// TODO (kasey): should we also remove any other blocks that have been added?
+						// also not catching or reporting the error here, as it seems more important to
+						// inform folks about the mismatch
+						f.bapi.Rm(f.ctx, bs.Path())
 						errCh <- fmt.Errorf("hash integrity mismatch. expected %s, got: %s", bs.Path().Cid().String(), res.Hash)
 					}
 

--- a/dsync/remote.go
+++ b/dsync/remote.go
@@ -132,7 +132,7 @@ func (rem *HTTPRemote) PutBlock(sid, hash string, data []byte) Response {
 	}
 }
 
-// ReqManifest gets a
+// ReqManifest requests a manifest from a remote source
 func (rem *HTTPRemote) ReqManifest(ctx context.Context, id string) (mfst *dag.Manifest, err error) {
 	url := fmt.Sprintf("%s?manifest=%s", rem.URL, id)
 	req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
changed stuff in `NewCompletion`, plz take a look

working under the assumption that a manifest and its diff have their nodes in the same order

added comments to places

added a `blockapi.rm` call to the `fetch.Do()` func