### PR TITLE
refactor(dsync): Split Do into two phases. TestReceivers.

### DIFF
--- a/dsync/send.go
+++ b/dsync/send.go
@@ -75,7 +75,18 @@ func (snd *Send) Do() (err error) {
 	if err != nil {
 		return err
 	}
+	return snd.doActualSend()
+}
 
+// PerformSend executes the send, given that we already have a session and diff
+func (snd *Send) PerformSend(sid string, mfst, diff *dag.Manifest) error {
+	snd.sid = sid
+	snd.mfst = mfst
+	snd.diff = diff
+	return snd.doActualSend()
+}
+
+func (snd *Send) doActualSend() (err error) {
 	snd.prog = dag.NewCompletion(snd.mfst, snd.diff)
 	go snd.completionChanged()
 	// defer close(snd.progCh)

--- a/dsync/test_receivers.go
+++ b/dsync/test_receivers.go
@@ -1,0 +1,60 @@
+package dsync
+
+import (
+	"context"
+	"io"
+	"time"
+
+	cid "gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
+	ipld "gx/ipfs/QmR7TcHkR9nxkUorfi8XMTAMLUK7GiP64TWWBzY3aacc1o/go-ipld-format"
+	coreiface "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi/interface"
+	"gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/coreapi/interface/options"
+)
+
+// NewTestReceivers returns a Receivers pointer suitable for testing, and not much else
+func NewTestReceivers() *Receivers {
+	return &Receivers{
+		ctx:     context.Background(),
+		lng:     newTestNodeGetter(),
+		bapi:    newTestBlockAPI(),
+		pool:    make(map[string]*Receive),
+		cancels: make(map[string]context.CancelFunc),
+		TTLDur:  time.Hour * 5,
+	}
+}
+
+type testNodeGetter struct{}
+
+func newTestNodeGetter() ipld.NodeGetter {
+	return &testNodeGetter{}
+}
+
+func (t *testNodeGetter) Get(context.Context, cid.Cid) (ipld.Node, error) {
+	return nil, nil
+}
+
+func (t *testNodeGetter) GetMany(context.Context, []cid.Cid) <-chan *ipld.NodeOption {
+	return nil
+}
+
+type testBlockAPI struct{}
+
+func newTestBlockAPI() coreiface.BlockAPI {
+	return &testBlockAPI{}
+}
+
+func (t *testBlockAPI) Put(context.Context, io.Reader, ...options.BlockPutOption) (coreiface.BlockStat, error) {
+	return nil, nil
+}
+
+func (t *testBlockAPI) Get(context.Context, coreiface.Path) (io.Reader, error) {
+	return nil, nil
+}
+
+func (t *testBlockAPI) Rm(context.Context, coreiface.Path, ...options.BlockRmOption) error {
+	return nil
+}
+
+func (t *testBlockAPI) Stat(context.Context, coreiface.Path) (coreiface.BlockStat, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Split Do into two parts: ReqSend and doActualSend. Add a second entry point `PerformSend` that skips ReqSend. This is needed for publishing to remotes, since ReqSend is called earlier, before the dsync begins.

Add TestReceivers for testing dsync using a mock Receivers.