### PR TITLE
fix(dsync pull): send metadata when doina dync getDagInfo

### DIFF
--- a/dsync/dsync.go
+++ b/dsync/dsync.go
@@ -469,6 +469,7 @@ func (ds *Dsync) GetDagInfo(ctx context.Context, hash string, meta map[string]st
 	}
 
 	if ds.getDagInfoCheck != nil {
+		log.Errorf("get dag info check meta: %v", meta)
 		if err = ds.getDagInfoCheck(ctx, *info, meta); err != nil {
 			return nil, err
 		}

--- a/dsync/dsync_test.go
+++ b/dsync/dsync_test.go
@@ -47,7 +47,7 @@ func ExampleNew() {
 	// Remote setup:
 	// setup the remote we're going to push to, starting by creating a local node
 	// getter
-	bLocalDS, err := NewLocalNodeGetter(nodeB)
+	bng, err := NewLocalNodeGetter(nodeB)
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +56,7 @@ func ExampleNew() {
 	bAddr := ":9595"
 
 	// create the remote instance, configuring it to accept DAGs
-	bDsync, err := New(bLocalDS, nodeB.Block(), func(cfg *Config) {
+	bDsync, err := New(bng, nodeB.Block(), func(cfg *Config) {
 		// configure the remote listening address:
 		cfg.HTTPRemoteAddress = bAddr
 

--- a/dsync/pull.go
+++ b/dsync/pull.go
@@ -15,6 +15,7 @@ import (
 func NewPull(cidStr string, lng ipld.NodeGetter, bapi coreiface.BlockAPI, rem DagSyncable, meta map[string]string) (pull *Pull, err error) {
 	f := &Pull{
 		path:        cidStr,
+		meta:        meta,
 		lng:         lng,
 		bapi:        bapi,
 		remote:      rem,

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ replace (
 )
 
 require (
+	github.com/google/go-cmp v0.2.0
 	github.com/ipfs/go-cid v0.0.2
 	github.com/ipfs/go-datastore v0.0.5
 	github.com/ipfs/go-ipfs v0.4.21


### PR DESCRIPTION
we weren't properly associating metadata with pull requests. Fixed, now with tests.