### PR TITLE
dsync version 0.2.0 supports CAR archive stream push & pull

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -2,6 +2,8 @@ package dag
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -16,7 +18,9 @@ func Missing(ctx context.Context, ng ipld.NodeGetter, m *Manifest) (missing *Man
 		if err != nil {
 			return nil, err
 		}
-		if _, err := ng.Get(ctx, id); err == ipld.ErrNotFound {
+
+		_, err = ng.Get(ctx, id)
+		if errors.Is(err, ipld.ErrNotFound) || (err != nil && strings.Contains(err.Error(), "not found")) {
 			nodes = append(nodes, id.String())
 		} else if err != nil {
 			return nil, err

--- a/dsync/dsync.go
+++ b/dsync/dsync.go
@@ -42,6 +42,8 @@ func init() {
 }
 
 const (
+	// DsyncProtocolID is the dsyc p2p Protocol Identifier & version tag
+	DsyncProtocolID = protocol.ID("/dsync/0.2.0")
 	// default to parallelism of 3. So far 4 was enough to blow up a std k8s pod running IPFS :(
 	defaultPushParallelism = 1
 	// default to parallelism of 3

--- a/dsync/http.go
+++ b/dsync/http.go
@@ -5,23 +5,29 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 
-	"github.com/ipfs/go-cid"
-	ipld "github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	protocol "github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/qri-io/dag"
 )
 
 const (
 	httpProtcolIDHeader = "dsync-version"
+	carArchiveMediaType = "archive/car"
+	cborMediaType       = "application/cbor"
+	sidHeader           = "sid"
 )
 
 // HTTPClient is the request side of doing dsync over HTTP
 type HTTPClient struct {
 	URL           string
+	NodeGetter    format.NodeGetter
+	BlockAPI      coreiface.BlockAPI
 	remProtocolID protocol.ID
 }
 
@@ -51,11 +57,12 @@ func (rem *HTTPClient) NewReceiveSession(info *dag.Info, pinOnComplete bool, met
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("POST", u.String(), buf)
+	req, err := http.NewRequest(http.MethodPost, u.String(), buf)
 	if err != nil {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(httpProtcolIDHeader, string(DsyncProtocolID))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -73,15 +80,7 @@ func (rem *HTTPClient) NewReceiveSession(info *dag.Info, pinOnComplete bool, met
 
 	sid = res.Header.Get("sid")
 
-	protocolIDHeaderStr := res.Header.Get(httpProtcolIDHeader)
-	if protocolIDHeaderStr == "" {
-		// protocol ID header only exists in version 0.2.0 and up, when header isn't
-		// present assume version 0.1.1, the latest version before header was set
-		// 0.1.1 is wire-compatible with all lower versions of dsync
-		rem.remProtocolID = protocol.ID("/dsync/0.1.1")
-	} else {
-		rem.remProtocolID = protocol.ID(protocolIDHeaderStr)
-	}
+	rem.remProtocolID = protocolIDFromHTTPData(req.URL, res.Header)
 
 	diff = &dag.Manifest{}
 	err = json.NewDecoder(res.Body).Decode(diff)
@@ -98,19 +97,17 @@ func (rem *HTTPClient) ProtocolVersion() (protocol.ID, error) {
 	return rem.remProtocolID, nil
 }
 
-// PutBlocks streams a manifest of blocks to the remote in one HTTP call
-func (rem *HTTPClient) PutBlocks(ctx context.Context, sid string, ng ipld.NodeGetter, mfst *dag.Manifest, progCh chan cid.Cid) error {
-	r, err := NewManifestCARReader(ctx, ng, mfst, progCh)
-	if err != nil {
-		log.Debugf("err creating CARReader err=%q ", err)
-		return err
-	}
+// ReceiveBlocks writes a block stream as an HTTP PUT request to the remote
+func (rem *HTTPClient) ReceiveBlocks(ctx context.Context, sid string, r io.Reader) error {
 
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s?sid=%s", rem.URL, sid), r)
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s?sid=%s", rem.URL, sid), r)
 	if err != nil {
-		log.Debugf("err creating PATCH HTTP request err=%q ", err)
+		log.Debugf("err creating %s HTTP request err=%q ", http.MethodPut, err)
 		return err
 	}
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", carArchiveMediaType)
+	req.Header.Set(httpProtcolIDHeader, string(DsyncProtocolID))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -130,15 +127,10 @@ func (rem *HTTPClient) PutBlocks(ctx context.Context, sid string, ng ipld.NodeGe
 	return nil
 }
 
-// FetchBlocks streams a manifest of requested blocks
-func (rem *HTTPClient) FetchBlocks(ctx context.Context, sid string, mfst *dag.Manifest, progCh chan cid.Cid) error {
-	return fmt.Errorf("not implemented")
-}
-
 // ReceiveBlock asks a remote to receive a block over HTTP
 func (rem *HTTPClient) ReceiveBlock(sid, hash string, data []byte) ReceiveResponse {
 	url := fmt.Sprintf("%s?sid=%s&hash=%s", rem.URL, sid, hash)
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(data))
 	if err != nil {
 		log.Debugf("http client create request error=%s", err)
 		return ReceiveResponse{
@@ -190,7 +182,7 @@ func (rem *HTTPClient) GetDagInfo(ctx context.Context, id string, meta map[strin
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +209,7 @@ func (rem *HTTPClient) GetDagInfo(ctx context.Context, id string, meta map[strin
 // GetBlock fetches a block from a remote source over HTTP
 func (rem *HTTPClient) GetBlock(ctx context.Context, id string) (data []byte, err error) {
 	url := fmt.Sprintf("%s?block=%s", rem.URL, id)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -239,6 +231,49 @@ func (rem *HTTPClient) GetBlock(ctx context.Context, id string) (data []byte, er
 	return ioutil.ReadAll(res.Body)
 }
 
+// OpenBlockStream sends a dag.Info to the remote & asks that it returns a
+// stream of blocks in the info's manifest
+func (rem *HTTPClient) OpenBlockStream(ctx context.Context, info *dag.Info, meta map[string]string) (io.ReadCloser, error) {
+	u, err := url.Parse(rem.URL)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	for key, value := range meta {
+		q.Add(key, value)
+	}
+	u.RawQuery = q.Encode()
+
+	bodyData, err := info.MarshalCBOR()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, u.String(), bytes.NewBuffer(bodyData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", cborMediaType)
+	req.Header.Set("Accept", carArchiveMediaType)
+	req.Header.Set(httpProtcolIDHeader, string(DsyncProtocolID))
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("unexpected HTTP response: %d: %q", res.StatusCode, string(body))
+	}
+
+	if res.Header.Get("Content-Type") != carArchiveMediaType {
+		return nil, fmt.Errorf("unexpected media type: %s", res.Header.Get("Content-Type"))
+	}
+
+	return res.Body, nil
+}
+
 // RemoveCID asks a remote to remove a CID
 func (rem *HTTPClient) RemoveCID(ctx context.Context, id string, meta map[string]string) (err error) {
 	u, err := url.Parse(rem.URL)
@@ -252,7 +287,7 @@ func (rem *HTTPClient) RemoveCID(ctx context.Context, id string, meta map[string
 	}
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("DELETE", u.String(), nil)
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -280,68 +315,24 @@ func (rem *HTTPClient) RemoveCID(ctx context.Context, id string, meta map[string
 // that interlocks with methods exposed by HTTPClient
 func HTTPRemoteHandler(ds *Dsync) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(httpProtcolIDHeader, string(DsyncProtocolID))
+
 		switch r.Method {
-		case "POST":
-			info := &dag.Info{}
-			if err := json.NewDecoder(r.Body).Decode(info); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				return
-			}
-			r.Body.Close()
-
-			if info == nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("body must be a json dag info object"))
-				return
-			}
-
-			pinOnComplete := r.FormValue("pin") == "true"
-			meta := map[string]string{}
-			for key := range r.URL.Query() {
-				if key != "pin" {
-					meta[key] = r.URL.Query().Get(key)
+		case http.MethodPost:
+			createDsyncSession(ds, w, r)
+		case http.MethodPut:
+			if r.Header.Get("Content-Type") == carArchiveMediaType {
+				if err := ds.ReceiveBlocks(r.Context(), r.FormValue("sid"), r.Body); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(err.Error()))
+					return
 				}
-			}
-
-			sid, diff, err := ds.NewReceiveSession(info, pinOnComplete, meta)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				return
-			}
-
-			w.Header().Set(httpProtcolIDHeader, string(DsyncProtocolID))
-			w.Header().Set("sid", sid)
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(diff)
-		case "PUT":
-			data, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				return
-			}
-
-			res := ds.ReceiveBlock(r.FormValue("sid"), r.FormValue("hash"), data)
-
-			if res.Status == StatusErrored {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(res.Err.Error()))
-			} else if res.Status == StatusRetry {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(res.Err.Error()))
-			} else {
 				w.WriteHeader(http.StatusOK)
-			}
-		case "PATCH":
-			if err := ds.ReceiveBlocks(r.Context(), r.FormValue("sid"), r.Body); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
 				return
 			}
-			w.WriteHeader(http.StatusOK)
-		case "GET":
+
+			receiveBlockHTTP(ds, w, r)
+		case http.MethodGet:
 			mfstID := r.FormValue("manifest")
 			blockID := r.FormValue("block")
 			if mfstID == "" && blockID == "" {
@@ -382,7 +373,32 @@ func HTTPRemoteHandler(ds *Dsync) http.HandlerFunc {
 				w.Header().Set("Content-Type", "application/octet-stream")
 				w.Write(data)
 			}
-		case "DELETE":
+		case http.MethodPatch:
+			meta := map[string]string{}
+			for key := range r.URL.Query() {
+				meta[key] = r.URL.Query().Get(key)
+			}
+
+			info, err := decodeDAGInfoBody(r)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			r, err := ds.OpenBlockStream(r.Context(), info, meta)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(err.Error()))
+				return
+			}
+
+			w.Header().Set("Content-Type", carArchiveMediaType)
+			w.WriteHeader(http.StatusOK)
+			defer r.Close()
+			io.Copy(w, r)
+			return
+
+		case http.MethodDelete:
 			cid := r.FormValue("cid")
 			meta := map[string]string{}
 			for key := range r.URL.Query() {
@@ -400,4 +416,94 @@ func HTTPRemoteHandler(ds *Dsync) http.HandlerFunc {
 			w.WriteHeader(http.StatusOK)
 		}
 	}
+}
+
+func protocolIDFromHTTPData(url *url.URL, headers http.Header) protocol.ID {
+	protocolIDHeaderStr := headers.Get(httpProtcolIDHeader)
+	if protocolIDHeaderStr == "" {
+		// protocol ID header only exists in version 0.2.0 and up, when header isn't
+		// present assume version 0.1.1, the latest version before header was set
+		// 0.1.1 is wire-compatible with all lower versions of dsync
+		return protocol.ID("/dsync/0.1.1")
+	}
+
+	return protocol.ID(protocolIDHeaderStr)
+}
+
+func decodeDAGInfoBody(r *http.Request) (*dag.Info, error) {
+	defer r.Body.Close()
+	info := &dag.Info{}
+
+	switch r.Header.Get("Content-Type") {
+	case cborMediaType:
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		info, err = dag.UnmarshalCBORDagInfo(data)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		// default to JSON for legacy reads
+		err := json.NewDecoder(r.Body).Decode(info)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if info.Manifest == nil {
+		return nil, fmt.Errorf("body must be a json dag info object")
+	}
+
+	return info, nil
+}
+
+func receiveBlockHTTP(ds *Dsync, w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	res := ds.ReceiveBlock(r.FormValue("sid"), r.FormValue("hash"), data)
+
+	if res.Status == StatusErrored {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(res.Err.Error()))
+	} else if res.Status == StatusRetry {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(res.Err.Error()))
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func createDsyncSession(ds *Dsync, w http.ResponseWriter, r *http.Request) {
+	info, err := decodeDAGInfoBody(r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	pinOnComplete := r.FormValue("pin") == "true"
+	meta := map[string]string{}
+	for key := range r.URL.Query() {
+		if key != "pin" {
+			meta[key] = r.URL.Query().Get(key)
+		}
+	}
+
+	sid, diff, err := ds.NewReceiveSession(info, pinOnComplete, meta)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	w.Header().Set(sidHeader, sid)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(diff)
 }

--- a/dsync/http_test.go
+++ b/dsync/http_test.go
@@ -26,8 +26,8 @@ func TestSyncHTTP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// yooooooooooooooooooooo
-	f := files.NewReaderFile(ioutil.NopCloser(strings.NewReader("y" + strings.Repeat("o", 350))))
+	// yooooooooooooooooooooo...
+	f := files.NewReaderFile(ioutil.NopCloser(strings.NewReader("y" + strings.Repeat("o", 3500000))))
 	path, err := a.Unixfs().Add(ctx, f)
 	if err != nil {
 		t.Fatal(err)
@@ -67,13 +67,14 @@ func TestSyncHTTP(t *testing.T) {
 
 	cli := &HTTPClient{URL: s.URL + "/dsync"}
 
+	fmt.Printf("pushing %#v\n", info.Manifest.Nodes)
 	push, err := NewPush(aGetter, info, cli, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err := push.Do(ctx); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// b should now be able to generate a manifest
@@ -85,7 +86,7 @@ func TestSyncHTTP(t *testing.T) {
 	<-onCompleteCalled
 
 	if err := cli.RemoveCID(ctx, info.RootCID().String(), nil); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	<-removeCheckCalled

--- a/dsync/http_test.go
+++ b/dsync/http_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -14,8 +17,9 @@ import (
 )
 
 func TestSyncHTTP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	ctx := context.Background()
 	_, a, err := makeAPI(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +71,7 @@ func TestSyncHTTP(t *testing.T) {
 
 	cli := &HTTPClient{URL: s.URL + "/dsync"}
 
-	fmt.Printf("pushing %#v\n", info.Manifest.Nodes)
+	t.Logf("pushing %#v\n", info.Manifest.Nodes)
 	push, err := NewPush(aGetter, info, cli, false)
 	if err != nil {
 		t.Fatal(err)
@@ -199,4 +203,124 @@ func TestHooksMetaHTTP(t *testing.T) {
 	}
 
 	// TODO (b5) - run a delete
+}
+
+func TestBackwardCompatibleClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, a, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, b, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, c, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// yooooooooooooooooooooo...
+	f := files.NewReaderFile(ioutil.NopCloser(strings.NewReader("y" + strings.Repeat("o", 3500000))))
+	path, err := a.Unixfs().Add(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aGetter := &dag.NodeGetter{Dag: a.Dag()}
+	info, err := dag.NewInfo(ctx, aGetter, path.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cGetter := &dag.NodeGetter{Dag: c.Dag()}
+	cdsync, err := New(cGetter, c.Block())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	onCompleteCalled := make(chan struct{}, 1)
+	onCompleteHook := func(_ context.Context, _ dag.Info, _ map[string]string) error {
+		onCompleteCalled <- struct{}{}
+		return nil
+	}
+
+	removeCheckCalled := make(chan struct{}, 1)
+	removeCheckHook := func(_ context.Context, _ dag.Info, _ map[string]string) error {
+		removeCheckCalled <- struct{}{}
+		return nil
+	}
+
+	bGetter := &dag.NodeGetter{Dag: b.Dag()}
+	bdsync, err := New(bGetter, b.Block(), func(cfg *Config) {
+		cfg.AllowRemoves = true
+		cfg.PushPreCheck = func(context.Context, dag.Info, map[string]string) error { return nil }
+		cfg.PushComplete = onCompleteHook
+		cfg.RemoveCheck = removeCheckHook
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := httptest.NewServer(HTTPRemoteHandler(bdsync))
+	defer s.Close()
+
+	remoteURL, err := url.Parse(s.URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rProxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = remoteURL.Scheme
+			req.URL.Host = remoteURL.Host
+			req.Header.Set(httpDsyncProtocolIDHeader, "")
+		},
+		ModifyResponse: func(res *http.Response) error {
+			res.Header.Set(httpDsyncProtocolIDHeader, "")
+			return nil
+		},
+	}
+
+	proxy := httptest.NewServer(rProxy)
+	defer proxy.Close()
+
+	cli := &HTTPClient{URL: proxy.URL + "/dsync"}
+
+	t.Logf("pushing %#v\n", info.Manifest.Nodes)
+	push, err := NewPush(aGetter, info, cli, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := push.Do(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// b should now be able to generate a manifest
+	_, err = dag.NewManifest(ctx, bGetter, path.Cid())
+	if err != nil {
+		t.Error(err)
+	}
+
+	<-onCompleteCalled
+
+	if err := cli.RemoveCID(ctx, info.RootCID().String(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	<-removeCheckCalled
+
+	pull, err := cdsync.NewPull(info.RootCID().String(), proxy.URL+"/dsync", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pull.Do(ctx); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/dsync/http_test.go
+++ b/dsync/http_test.go
@@ -90,6 +90,14 @@ func TestSyncHTTP(t *testing.T) {
 	}
 
 	<-removeCheckCalled
+
+	r, err := cli.OpenBlockStream(ctx, info, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ioutil.ReadAll(r); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRemoveNotSupported(t *testing.T) {
@@ -161,6 +169,7 @@ func TestHooksMetaHTTP(t *testing.T) {
 		cfg.PushFinalCheck = checkMeta("PushFinalCheck")
 		cfg.PushComplete = checkMeta("PushComplete")
 		cfg.GetDagInfoCheck = checkMeta("GetDagInfoCheck")
+		cfg.OpenBlockStreamCheck = checkMeta("OpenBlockStreamCheck")
 		cfg.RemoveCheck = checkMeta("RemoveCheck")
 	})
 	if err != nil {

--- a/dsync/p2p.go
+++ b/dsync/p2p.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	// DsyncProtocolID is the dsyc p2p Protocol Identifier & version tag
-	DsyncProtocolID = protocol.ID("/dsync/0.2.0")
 	// default value to give qri peer connections in connmanager, one hunnit
 	dsyncSupportValue = 100
 )

--- a/dsync/pull.go
+++ b/dsync/pull.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/qri-io/dag"
 
+	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 )
@@ -99,6 +100,44 @@ func (f *Pull) Do(ctx context.Context) (err error) {
 }
 
 func (f *Pull) do(ctx context.Context) error {
+	protoID, err := f.remote.ProtocolVersion()
+	if err != nil {
+		return err
+	}
+
+	if protocolSupportsDagStreaming(protoID) {
+		if streamable, ok := f.remote.(DagStreamable); ok {
+			progCh := make(chan cid.Cid)
+			go func() {
+				for {
+					select {
+					case cid := <-progCh:
+						// this is the only place we should modify progress after creation
+						for i, hash := range f.info.Manifest.Nodes {
+							if cid.String() == hash {
+								f.prog[i] = 100
+								go f.completionChanged()
+								break
+							}
+						}
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+
+			r, err := streamable.OpenBlockStream(ctx, f.info, f.meta)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+
+			_, err = AddAllFromCARReader(ctx, f.bapi, r, progCh)
+			return err
+		}
+		log.Debugf("protocol supports streaming but doesn't have the streamable interface: %T %v", f.remote, f.remote)
+	}
+
 	if len(f.diff.Nodes) < f.parallelism {
 		f.parallelism = len(f.diff.Nodes)
 	}

--- a/dsync/pull.go
+++ b/dsync/pull.go
@@ -138,6 +138,8 @@ func (f *Pull) do(ctx context.Context) error {
 		log.Debugf("protocol supports streaming but doesn't have the streamable interface: %T %v", f.remote, f.remote)
 	}
 
+	log.Debugf("protocol doesn't support block streaming. falling back to pulling per-block strategy")
+
 	if len(f.diff.Nodes) < f.parallelism {
 		f.parallelism = len(f.diff.Nodes)
 	}

--- a/dsync/push.go
+++ b/dsync/push.go
@@ -157,6 +157,8 @@ func (snd *Push) do(ctx context.Context) (err error) {
 		}
 	}
 
+	log.Debugf("protocol doesn't support block streaming. falling back to pushing per-block strategy")
+
 	// create senders
 	sends := make([]sender, snd.parallelism)
 	for i := 0; i < snd.parallelism; i++ {

--- a/dsync/push.go
+++ b/dsync/push.go
@@ -124,6 +124,33 @@ func (snd *Push) do(ctx context.Context) (err error) {
 		return nil
 	}
 
+	protoID, err := snd.remote.ProtocolVersion()
+	if err != nil {
+		return err
+	}
+
+	if protocolSupportsDagStreaming(protoID) {
+		progCh := make(chan cid.Cid)
+
+		go func() {
+			for id := range progCh {
+				// this is the only place we should modify progress after creation
+				idStr := id.String()
+				log.Debugf("sent block %s", idStr)
+				for i, hash := range snd.info.Manifest.Nodes {
+					if idStr == hash {
+						snd.prog[i] = 100
+					}
+				}
+				go snd.completionChanged()
+			}
+		}()
+
+		if str, ok := snd.remote.(DagStreamable); ok {
+			return str.PutBlocks(ctx, snd.sid, snd.lng, snd.diff, progCh)
+		}
+	}
+
 	// create senders
 	sends := make([]sender, snd.parallelism)
 	for i := 0; i < snd.parallelism; i++ {

--- a/dsync/session.go
+++ b/dsync/session.go
@@ -165,18 +165,3 @@ func randStringBytesMask(n int) string {
 
 	return string(b)
 }
-
-// type blockApiHaser struct {
-// 	bapi coreiface.BlockAPI
-// }
-
-// func (bh blockApiHaser) Has(id cid.Cid) (bool, error) {
-// 	st, err := bh.bapi.Stat(context.Background(), path.IpfsPath(id))
-// 	if errors.Is() {
-
-// 	}
-// }
-
-// func NewBlockAPIHaser(bapi coreiface.BlockAPI) dag.BlockHaser {
-
-// }

--- a/dsync/session.go
+++ b/dsync/session.go
@@ -15,10 +15,11 @@ import (
 
 // session tracks the state of a transfer
 type session struct {
+	ctx  context.Context
+	lng  ipld.NodeGetter
+	bapi coreiface.BlockAPI
+
 	id     string
-	ctx    context.Context
-	lng    ipld.NodeGetter
-	bapi   coreiface.BlockAPI
 	pin    bool
 	meta   map[string]string
 	info   *dag.Info
@@ -36,6 +37,7 @@ func newSession(ctx context.Context, lng ipld.NodeGetter, bapi coreiface.BlockAP
 	if calcBlockDiff {
 		log.Debug("calculating block diff")
 		if diff, err = dag.Missing(ctx, lng, info.Manifest); err != nil {
+			log.Debugf("error calculating diff err=%q", err)
 			return nil, err
 		}
 	}
@@ -100,7 +102,6 @@ func (s *session) ReceiveBlocks(ctx context.Context, r io.Reader) error {
 	go func() {
 		for id := range progCh {
 			idStr := id.String()
-			// this should be the only place that modifies progress
 			for i, h := range s.info.Manifest.Nodes {
 				if idStr == h {
 					s.prog[i] = 100
@@ -164,3 +165,18 @@ func randStringBytesMask(n int) string {
 
 	return string(b)
 }
+
+// type blockApiHaser struct {
+// 	bapi coreiface.BlockAPI
+// }
+
+// func (bh blockApiHaser) Has(id cid.Cid) (bool, error) {
+// 	st, err := bh.bapi.Stat(context.Background(), path.IpfsPath(id))
+// 	if errors.Is() {
+
+// 	}
+// }
+
+// func NewBlockAPIHaser(bapi coreiface.BlockAPI) dag.BlockHaser {
+
+// }

--- a/dsync/stream.go
+++ b/dsync/stream.go
@@ -1,0 +1,182 @@
+package dsync
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipld/go-car"
+	carutil "github.com/ipld/go-car/util"
+	protocol "github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/qri-io/dag"
+)
+
+// DagStreamable is an interface for sending and fetching all blocks in a given
+// manifest in one trip
+type DagStreamable interface {
+	PutBlocks(ctx context.Context, sid string, ng ipld.NodeGetter, mfst *dag.Manifest, progCh chan cid.Cid) error
+	FetchBlocks(ctx context.Context, sid string, mfst *dag.Manifest, progCh chan cid.Cid) error
+}
+
+func protocolSupportsDagStreaming(pid protocol.ID) bool {
+	versions := strings.Split(strings.TrimPrefix(string(pid), "/dsync/"), ".")
+	if len(versions) != 3 {
+		log.Debugf("unexpected version string in protocol.ID pid=%q versions=%v", pid, versions)
+		return false
+	}
+
+	major, err := strconv.Atoi(versions[0])
+	if err != nil {
+		log.Debugf("error parsing major version number in protocol.ID pid=%q versions=%v", pid, versions)
+		return false
+	}
+
+	minor, err := strconv.Atoi(versions[1])
+	if err != nil {
+		log.Debugf("error parsing minor version number in protocol.ID pid=%q versions=%v", pid, versions)
+		return false
+	}
+
+	// anything above 0.2 is considered to support Dag Streaming
+	return major >= 0 && minor >= 2
+}
+
+// NewManifestCARReader creates a Content-addressed ARchive on the fly from a manifest
+// and a node getter. It fetches blocks in order from the list of cids in the
+// manifest and writes them to a buffer as the reader is consumed
+// The roots specified in the archive header match the manifest RootCID method
+// If an incomplete manifest graph is passed to NewManifestCARReader, the resulting
+// archive will not be a complete graph. This is permitted by the spec, and
+// used by dsync to create an archive of only-missing-blocks
+// for more on CAR files, see: https://github.com/ipld/specs/blob/master/block-layer/content-addressable-archives.md
+// If supplied a non-nil channel progress channel, the stream will send as
+// each CID is buffered to the read stream
+func NewManifestCARReader(ctx context.Context, ng ipld.NodeGetter, mfst *dag.Manifest, progCh chan cid.Cid) (io.Reader, error) {
+
+	cids := make([]cid.Cid, 0, len(mfst.Nodes))
+	for _, cidStr := range mfst.Nodes {
+		id, err := cid.Decode(cidStr)
+		if err != nil {
+			return nil, err
+		}
+		id, err = cid.Cast(id.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		cids = append(cids, id)
+	}
+
+	buf := &bytes.Buffer{}
+	header := &car.CarHeader{
+		Roots:   []cid.Cid{mfst.RootCID()},
+		Version: 1,
+	}
+	err := car.WriteHeader(header, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	str := &mfstCarReader{
+		ctx:    ctx,
+		cids:   cids,
+		ng:     ng,
+		buf:    buf,
+		progCh: progCh,
+	}
+	return str, nil
+}
+
+type mfstCarReader struct {
+	i      int
+	ctx    context.Context
+	cids   []cid.Cid
+	ng     ipld.NodeGetter
+	buf    *bytes.Buffer
+	progCh chan cid.Cid
+}
+
+func (str *mfstCarReader) Read(p []byte) (int, error) {
+	for {
+		// check for remaining bytes after last block is read
+		if str.i == len(str.cids) && str.buf.Len() > 0 {
+			return str.buf.Read(p)
+		}
+
+		// break loop on sufficent buffer length
+		if str.buf.Len() > len(p) {
+			break
+		}
+
+		if err := str.readBlock(); err != nil {
+			return 0, err
+		}
+	}
+
+	return io.ReadFull(str.buf, p)
+}
+
+// readBlock extends the buffer by one block
+func (str *mfstCarReader) readBlock() error {
+	if str.i == len(str.cids) {
+		return io.EOF
+	}
+	nd, err := str.ng.Get(str.ctx, str.cids[str.i])
+	if err != nil {
+		fmt.Printf("error getting block: %s\n", err)
+		return err
+	}
+
+	str.i++
+	if err = carutil.LdWrite(str.buf, nd.Cid().Bytes(), nd.RawData()); err != nil {
+		return err
+	}
+
+	if str.progCh != nil {
+		go func() { str.progCh <- nd.Cid() }()
+	}
+
+	return nil
+}
+
+// AddAllFromCARReader consumers a CAR reader stream, placing all blocks in the
+// given blockstore
+func AddAllFromCARReader(ctx context.Context, bapi coreiface.BlockAPI, r io.Reader, progCh chan cid.Cid) (int, error) {
+	rdr, err := car.NewCarReader(r)
+	if err != nil {
+		return 0, err
+	}
+
+	added := 0
+	buf := &bytes.Buffer{}
+	for {
+		blk, err := rdr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return added, err
+		}
+
+		if _, err := buf.Write(blk.RawData()); err != nil {
+			return added, err
+		}
+		if _, err = bapi.Put(ctx, buf); err != nil {
+			return added, err
+		}
+
+		buf.Reset()
+		added++
+
+		log.Debugf("wrote block %s", blk.Cid())
+		if progCh != nil {
+			go func() { progCh <- blk.Cid() }()
+		}
+	}
+
+	return added, nil
+}

--- a/dsync/stream_test.go
+++ b/dsync/stream_test.go
@@ -1,0 +1,99 @@
+package dsync
+
+import (
+	"context"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	files "github.com/ipfs/go-ipfs-files"
+	protocol "github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/qri-io/dag"
+)
+
+func TestCarStream(t *testing.T) {
+	ctx := context.Background()
+	_, a, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, b, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// yooooooooooooooooooooo...
+	f := files.NewReaderFile(ioutil.NopCloser(strings.NewReader("y" + strings.Repeat("o", 350000))))
+	path, err := a.Unixfs().Add(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aGetter := &dag.NodeGetter{Dag: a.Dag()}
+
+	mfst, err := dag.NewManifest(ctx, aGetter, path.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sentOnChan []cid.Cid
+	progCh := make(chan cid.Cid)
+	done := make(chan struct{})
+	go func() {
+		for {
+			cid := <-progCh
+			sentOnChan = append(sentOnChan, cid)
+			if len(sentOnChan) == len(mfst.Nodes) {
+				done <- struct{}{}
+			}
+		}
+	}()
+
+	r, err := NewManifestCARReader(ctx, aGetter, mfst, progCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := AddAllFromCARReader(ctx, b.Block(), r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mfst.Nodes) != added {
+		t.Errorf("scanned blocks mismatch. wanted: %d got: %d", len(mfst.Nodes), added)
+	}
+
+	<-done
+	// TODO (b5) - refactore manifest.Nodes to be of type []cid.Cid & compare
+	// slices to be exact here
+	if len(mfst.Nodes) != len(sentOnChan) {
+		t.Errorf("progress cids channel mismatch. wanted: %d got: %d", len(mfst.Nodes), len(sentOnChan))
+	}
+}
+
+func TestProtocolSupportsDagStreaming(t *testing.T) {
+	cases := []struct {
+		pid    protocol.ID
+		expect bool
+	}{
+		{"/dsync/0.2.0", true},
+		{"/dsync/0.2.1", true},
+		{"/dsync/1.28.10", true},
+
+		{"/dsync/0.1.0", false},
+		{"/dsync/", false},
+		{"/dsync/bad.number.10", false},
+		{"/dsync/1.huh?.10", false},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.pid), func(t *testing.T) {
+			got := protocolSupportsDagStreaming(c.pid)
+			if c.expect != got {
+				t.Errorf("support for %q mismatch. want: %t got: %t", c.pid, c.expect, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-log v1.0.4
 	github.com/ipfs/interface-go-ipfs-core v0.3.0
+	github.com/ipld/go-car v0.1.0
 	github.com/libp2p/go-libp2p v0.11.0
 	github.com/libp2p/go-libp2p-core v0.6.1
 	github.com/libp2p/go-libp2p-peerstore v0.2.6


### PR DESCRIPTION
Old version of dsync was doing one HTTP request _per block_. no bueno. This change adds protocol version negotiation, and if version 0.2.0 or higher are detected, dsync push & pull over HTTP uses a stream of blocks as _one_ HTTP request. 

This is _not_ a breaking change, should be backwards compatible with a fallback. Tests currently don't cover a backwards compatibility check, and really should. 